### PR TITLE
Update date range frequency from '15T' to '15min' in example data generation and fixture files

### DIFF
--- a/docs/data/generate_example_data.py
+++ b/docs/data/generate_example_data.py
@@ -6,7 +6,7 @@ def generate_example_data():
         index=pd.date_range(
             start="2023-01-01",
             end="2023-12-31",
-            freq="15T",
+            freq="15min",
             tz="Europe/Amsterdam",
             name="datetime",
         ),

--- a/tests/fixtures/dt_index_fixtures.py
+++ b/tests/fixtures/dt_index_fixtures.py
@@ -5,26 +5,35 @@ import pytest
 @pytest.fixture
 def idx_ams_2022():
     return pd.date_range(
-        start="2022-01-01", end="2022-12-31 23:45:00", freq="15T", tz="Europe/Amsterdam"
+        start="2022-01-01",
+        end="2022-12-31 23:45:00",
+        freq="15min",
+        tz="Europe/Amsterdam",
     ).tz_localize(None)
 
 
 @pytest.fixture
 def idx_ams_2023():
     return pd.date_range(
-        start="2023-01-01", end="2023-12-31 23:45:00", freq="15T", tz="Europe/Amsterdam"
+        start="2023-01-01",
+        end="2023-12-31 23:45:00",
+        freq="15min",
+        tz="Europe/Amsterdam",
     ).tz_localize(None)
 
 
 @pytest.fixture
 def idx_ny_2023():
     return pd.date_range(
-        start="2023-01-01", end="2023-12-31 23:45:00", freq="15T", tz="America/New_York"
+        start="2023-01-01",
+        end="2023-12-31 23:45:00",
+        freq="15min",
+        tz="America/New_York",
     ).tz_localize(None)
 
 
 @pytest.fixture
 def idx_utc_2023():
     return pd.date_range(
-        start="2023-01-01", end="2023-12-31 23:45:00", freq="15T", tz="UTC"
+        start="2023-01-01", end="2023-12-31 23:45:00", freq="15min", tz="UTC"
     ).tz_localize(None)


### PR DESCRIPTION
closes #10 

### Description

This pull request refines the frequency parameter in date range generation within the following files:
- `docs/data/generate_example_data.py`
- `tests/fixtures/dt_index_fixtures.py`

**Changes include:**
1. Updated the frequency argument in `pd.date_range()` from `'15T'` to `'15min'` for clarity and consistency.
2. Applied changes in both the example data generation script and the fixture files used for testing date ranges across various time zones (e.g., Europe/Amsterdam, America/New_York, UTC).

These adjustments enhance code readability by making the frequency parameter more explicit without affecting the functionality or output.

**Testing:**
All tests utilizing the modified fixtures pass as expected, confirming that the change does not introduce any regressions.