### PR TITLE
Refactor `transition_data` variable names for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ from tz_canary import TransitionsData, infer_time_zone
 
 # We create a TransitionsData object to avoid having to recompute the transitions for
 #   every call to validate_time_zone.
-transition_data = TransitionsData(2010, 2023)
+transitions_data = TransitionsData(2010, 2023)
 
 for i in range(10):
     df = pd.read_csv(
@@ -75,7 +75,7 @@ for i in range(10):
         index_col="datetime",
         parse_dates=True,
     )
-    plausible_time_zones = infer_time_zone(df.index, transition_data=transition_data)
+    plausible_time_zones = infer_time_zone(df.index, transitions_data=transitions_data)
     print(i, plausible_time_zones)
 ```
 

--- a/docs/examples/example_many.py
+++ b/docs/examples/example_many.py
@@ -4,7 +4,7 @@ from tz_canary import TransitionsData, infer_time_zone
 
 # We create a TransitionsData object to avoid having to recompute the transitions for
 #   every call to validate_time_zone.
-transition_data = TransitionsData(2010, 2023)
+transitions_data = TransitionsData(2010, 2023)
 
 for i in range(10):
     df = pd.read_csv(
@@ -12,5 +12,5 @@ for i in range(10):
         index_col="datetime",
         parse_dates=True,
     )
-    plausible_time_zones = infer_time_zone(df.index, transition_data=transition_data)
+    plausible_time_zones = infer_time_zone(df.index, transitions_data=transitions_data)
     print(i, plausible_time_zones)

--- a/tz_canary/infer.py
+++ b/tz_canary/infer.py
@@ -11,13 +11,13 @@ logger = logging.getLogger(__name__)
 
 
 def infer_time_zone(
-    dt_index: pd.DatetimeIndex, transition_data: Optional[TransitionsData] = None
+    dt_index: pd.DatetimeIndex, transitions_data: Optional[TransitionsData] = None
 ) -> Set[ZoneInfo]:
     """Infer a set of plausible time zones based on DST switches.
 
     Args:
         dt_index: A pandas DatetimeIndex.
-        transition_data: A TransitionsData object. If None, the TransitionsData will be
+        transitions_data: A TransitionsData object. If None, the TransitionsData will be
             built for the years spanning the given index. When inferring time zones for
             many indices, it is more efficient to build a TransitionsData object once
             and pass it to multiple calls of this function.
@@ -26,8 +26,8 @@ def infer_time_zone(
         A set of plausible time zones for the given index.
     """
 
-    if transition_data is None:
-        transition_data = TransitionsData(
+    if transitions_data is None:
+        transitions_data = TransitionsData(
             year_start=dt_index.min().year, year_end=dt_index.max().year
         )
 
@@ -41,11 +41,11 @@ def infer_time_zone(
         dt_index = dt_index.tz_localize(None)
 
     # Find plausible time zones.
-    all_time_zones = set(ZoneInfo(tz) for tz in transition_data.tz_transitions.keys())
+    all_time_zones = set(ZoneInfo(tz) for tz in transitions_data.tz_transitions.keys())
     plausible_time_zones = set()  # all expected DST transitions occur
     implausible_time_zones = set()  # at least one expected DST transition doesn't occur
 
-    for tz_name, transitions in transition_data.tz_transitions.items():
+    for tz_name, transitions in transitions_data.tz_transitions.items():
         # Check if each transition occurs, does not occur, or is out of range.
         transition_occurrences = [
             _check_transition_occurs(dt_index, tz_name, transition)

--- a/tz_canary/transitions_data.py
+++ b/tz_canary/transitions_data.py
@@ -53,7 +53,7 @@ class TransitionsData:
 
 
 if __name__ == "__main__":
-    transition_data = TransitionsData()
+    transitions_data = TransitionsData()
     from pprint import pprint
 
-    pprint(transition_data.tz_transitions["Europe/Amsterdam"])
+    pprint(transitions_data.tz_transitions["Europe/Amsterdam"])

--- a/tz_canary/validate.py
+++ b/tz_canary/validate.py
@@ -11,7 +11,7 @@ from tz_canary.transitions_data import TransitionsData
 def validate_time_zone(
     dt_index: pd.DatetimeIndex,
     time_zone: Union[str, ZoneInfo] = None,
-    transition_data: Optional[TransitionsData] = None,
+    transitions_data: Optional[TransitionsData] = None,
 ) -> None:
     """Validate that the given time zone is plausible given DST changes in the index.
 
@@ -28,7 +28,7 @@ def validate_time_zone(
             argument must be given.
         time_zone: A time zone to validate. If `time_zone` is given, `dt_index` must be
             time-zone-naive.
-        transition_data: A TransitionsData object. If None, the TransitionsData will be
+        transitions_data: A TransitionsData object. If None, the TransitionsData will be
             built for the years spanning the given index. When inferring time zones for
             many indices, it is more efficient to build a TransitionsData object once
             and pass it to multiple calls of this function.
@@ -49,7 +49,7 @@ def validate_time_zone(
     if isinstance(given_time_zone, str):
         given_time_zone = ZoneInfo(given_time_zone)
 
-    plausible_time_zones = infer_time_zone(dt_index, transition_data)
+    plausible_time_zones = infer_time_zone(dt_index, transitions_data)
 
     if given_time_zone not in plausible_time_zones:
         raise ImplausibleTimeZoneError(


### PR DESCRIPTION
⚠️ breaking change

closes #2 

This pull request updates the naming of the `transition_data` variable to `transitions_data` across multiple files to ensure consistency with the class name and improve code readability. The changes affect the following files:

- **README.md**: Updated variable names in usage examples.
- **docs/examples/example_many.py**: Adjusted variable names in the examples.
- **tz_canary/infer.py**: Refactored function arguments and internal variable names.
- **tz_canary/transitions_data.py**: Adjusted variable references in class instantiation and examples.
- **tz_canary/validate.py**: Updated function arguments and logic for validating time zones.